### PR TITLE
docs: add codex prompts

### DIFF
--- a/.codex/prompts/00_bootstrap.md
+++ b/.codex/prompts/00_bootstrap.md
@@ -1,0 +1,10 @@
+You are an expert Python trading infra engineer. Create the initial project for a crypto spot trading bot using Python 3.11 and Poetry. 
+Tasks:
+- Add pyproject.toml with dependencies: ccxt, backtesting, pandas, numpy, scipy, ta, pydantic, loguru, python-telegram-bot, python-dotenv, pytest.
+- Create the file/folder structure listed below EXACTLY.
+- Add Dockerfile (multi-stage: builder->runtime) and Makefile with targets: install, lint, test, run, backtest.
+- Create .env.example with BINANCE_API_KEY, BINANCE_API_SECRET, TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, BASE_EQUITY, MAX_DAILY_LOSS_PCT, RISK_PER_TRADE_PCT.
+- Create config/config.example.yaml with default settings: timeframe: "1h", symbol: "BTC/USDT", exchange: "binance", slippage_bps: 5, atr_period: 14, risk_rr: 2.0, ema_fast: 50, ema_slow: 200, rsi_period: 14, rsi_buy_min: 45, rsi_buy_max: 60.
+- Implement minimal README with quickstart (Poetry and Docker), environment setup, and safety notes (no withdrawals).
+- Add .github/workflows/ci.yml: run lint (ruff if added) and pytest; and .github/workflows/nightly.yml: schedule daily backtests across parameter grid and upload artifacts (csv + html plots).
+Output only changed files with their full paths and contents.

--- a/.codex/prompts/01_exchange.md
+++ b/.codex/prompts/01_exchange.md
@@ -1,0 +1,6 @@
+Implement src/bot/exchange.py:
+- Binance spot only via ccxt with methods: get_balance(quote), get_price(symbol), fetch_ohlcv(symbol, timeframe, limit), create_market_buy(symbol, qty), create_market_sell(symbol, qty), create_oco_takeprofit_stoploss(symbol, qty, tp_price, sl_price) (simulate OCO if not available in spot).
+- Enforce safety: no withdrawals; max notional per trade from config; symbol whitelist.
+- Add robust retry with exponential backoff and rate-limit handling.
+- Unit tests in tests/test_exchange.py using ccxt sandbox mocking (pytest + monkeypatch).
+Return all new/changed files.

--- a/.codex/prompts/02_risk_position.md
+++ b/.codex/prompts/02_risk_position.md
@@ -1,0 +1,5 @@
+Create src/bot/risk.py and src/bot/position.py:
+- risk.py: compute stop loss using recent swing low/high or ATR*k (k from config), max_daily_loss_guard(state), and kill_switch(state).
+- position.py: position_size(entry, stop, equity, risk_pct) with flooring to exchange lot size.
+- tests for both modules; include edge cases (tiny ATR, tight stop).
+Return changed files.

--- a/.codex/prompts/03_strategy.md
+++ b/.codex/prompts/03_strategy.md
@@ -1,0 +1,8 @@
+Implement src/bot/strategy.py:
+- Indicators: EMA(fast=50), EMA(slow=200), RSI(14).
+- Long entry: EMAfast > EMAslow, RSI within [rsi_buy_min, rsi_buy_max], candle closes above EMAfast, pullback confirmation (previous close > current close).
+- Exit: TP at R:R >= config.risk_rr; SL at stop derived from risk module.
+- No shorts initially.
+- All logic must operate on candle-close signals (no intrabar lookahead).
+- Add tests verifying signals on synthetic data.
+Return changes.

--- a/.codex/prompts/04_paper_runner.md
+++ b/.codex/prompts/04_paper_runner.md
@@ -1,0 +1,12 @@
+Implement src/bot/paper.py and src/bot/runner.py:
+- paper.py: simulate orders, PnL, fees (maker/taker from config), slippage (bps).
+- runner.py: main loop, loads config + .env; 
+  1) fetch last N candles; 
+  2) generate signal using strategy; 
+  3) check guards (max daily loss, kill switch); 
+  4) compute size; 
+  5) simulate/execute order (paper first).
+- Add CLI: `python -m bot.runner --paper --config config/config.yaml`.
+- Add logging with loguru; Telegram notifier on entries/exits and when guards trigger.
+- Tests: deterministic paper fills and guard triggers.
+Return changes.

--- a/.codex/prompts/05_backtest_metrics.md
+++ b/.codex/prompts/05_backtest_metrics.md
@@ -1,0 +1,7 @@
+Implement src/bot/backtest.py and src/bot/metrics.py:
+- Backtesting wrapper to run parameter grid (ema_fast, ema_slow, rsi window/bounds, atr k, rr).
+- Metrics: CAGR, Sharpe (simple), Max Drawdown, Winrate, Profit Factor, Expectancy, Avg Trade.
+- Output: CSV summary + per-run equity curve PNG/HTML (plotly ok).
+- Add CLI: `python -m bot.backtest --symbol BTC/USDT --timeframe 1h --years 2 --grid default`.
+- Tests for metrics correctness on synthetic series.
+Return changes.

--- a/.codex/prompts/06_ci_nightly_issues.md
+++ b/.codex/prompts/06_ci_nightly_issues.md
@@ -1,0 +1,6 @@
+Enhance .github/workflows/nightly.yml to:
+- Run backtests on a small grid.
+- Upload artifacts (CSV + plots).
+- If best Sharpe < threshold or MaxDD > threshold, create a GitHub Issue summarizing stats and pointing to artifacts.
+Implement .github/ISSUE_TEMPLATE/backtest_regression.md.
+Return changes.

--- a/.codex/prompts/07_live_trading.md
+++ b/.codex/prompts/07_live_trading.md
@@ -1,0 +1,7 @@
+Extend runner to add `--live` mode:
+- Fetch balance and compute size with live equity.
+- Place market order and emulate OCO TP/SL via two GTC orders if needed, with asynchronous watcher that cancels the other when one fills.
+- Safety: notional cap, daily loss guard reading closed PnL from recent trades.
+- Dry-run flag that logs all would-be orders without sending.
+Add README “Go-Live Checklist”.
+Return changes.

--- a/.codex/prompts/08_optimize_params.md
+++ b/.codex/prompts/08_optimize_params.md
@@ -1,0 +1,5 @@
+Using the latest nightly artifacts (CSV results, equity curves), adjust the default parameter grid to prioritize regions with higher Sharpe and lower MaxDD. 
+- Update config/config.example.yaml defaults accordingly.
+- Propose 2 alternative entry filters (e.g., ADX>20, or volume surge confirmation) and implement them behind config flags.
+- Add A/B backtests comparing baseline vs new filters; update README with findings (tables + brief narrative).
+Return all modifications.

--- a/.codex/prompts/09_refactor_signals.md
+++ b/.codex/prompts/09_refactor_signals.md
@@ -1,0 +1,5 @@
+Refactor signal generation for cleanliness and low latency:
+- Streamline indicator calculations and avoid redundant recomputations.
+- Optimize data handling to reduce latency in live trading.
+- Update tests to cover refactored signal logic.
+Return all changes.

--- a/.codex/prompts/10_additional_pairs.md
+++ b/.codex/prompts/10_additional_pairs.md
@@ -1,0 +1,5 @@
+Enable trading for ETH/USDT and BNB/USDT:
+- Implement risk caps per pair.
+- Add correlation check to avoid opening more than 3 highly correlated trades simultaneously.
+- Update configuration and tests for multi-pair support.
+Return modifications.


### PR DESCRIPTION
## Summary
- add `.codex/prompts` directory with step-by-step development prompts for the trading bot

## Testing
- `ruff check .`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895590c34108320b044fb727731dd29